### PR TITLE
Add advanced deep-learning models and training script

### DIFF
--- a/backend/models/model_trainer.py
+++ b/backend/models/model_trainer.py
@@ -24,7 +24,22 @@ from sklearn.metrics import accuracy_score, precision_score, recall_score, f1_sc
 try:
     import tensorflow as tf
     from tensorflow.keras.models import Sequential, Model
-    from tensorflow.keras.layers import LSTM, GRU, Dense, Dropout, Input, Conv1D, MaxPooling1D, Flatten
+    from tensorflow.keras.layers import (
+        LSTM,
+        GRU,
+        Dense,
+        Dropout,
+        Input,
+        Conv1D,
+        MaxPooling1D,
+        Flatten,
+        GlobalAveragePooling1D,
+        Concatenate,
+        LayerNormalization,
+        Add,
+        Lambda,
+        MultiHeadAttention,
+    )
     from tensorflow.keras.optimizers import Adam
     from tensorflow.keras.callbacks import EarlyStopping, ModelCheckpoint, ReduceLROnPlateau
     TENSORFLOW_AVAILABLE = True
@@ -229,8 +244,185 @@ class ModelTrainer:
             loss='sparse_categorical_crossentropy' if num_classes > 2 else 'binary_crossentropy',
             metrics=['accuracy']
         )
-        
+
         return model
+
+    def create_tcn_model(
+        self,
+        input_shape: Tuple[int, int],
+        num_classes: int = 2,
+        loss_type: str = "crossentropy",
+    ) -> Optional[Model]:
+        """创建TCN/1D CNN模型
+
+        该模型采用空洞卷积构建的时间卷积网络（Temporal Convolutional Network, TCN）。
+        通过不同空洞率的卷积堆叠捕捉不同时间尺度的特征，并构建短、长两条分支后拼接。
+
+        Args:
+            input_shape: 输入张量形状 ``(时间步, 特征数)``
+            num_classes: 分类类别数
+            loss_type: ``"crossentropy"`` 使用交叉熵；``"focal"`` 使用focal loss
+
+        Returns:
+            构建好的 ``tf.keras.Model`` 模型实例
+        """
+
+        if not TENSORFLOW_AVAILABLE:
+            print("TensorFlow未安装，无法创建TCN模型")
+            return None
+
+        inputs = Input(shape=input_shape)
+
+        def tcn_block(x: tf.Tensor, filters: int) -> tf.Tensor:
+            """TCN核心模块，包含多层空洞卷积与残差连接"""
+            for d in [1, 2, 4, 8, 16]:
+                residual = x
+                x = Conv1D(
+                    filters,
+                    kernel_size=3,
+                    padding="causal",
+                    dilation_rate=d,
+                    activation="relu",
+                    kernel_regularizer=tf.keras.regularizers.l2(1e-4),
+                )(x)
+                x = LayerNormalization()(x)
+                x = Dropout(0.1)(x)
+                if residual.shape[-1] != x.shape[-1]:
+                    residual = Conv1D(filters, 1, padding="same")(residual)
+                x = Add()([x, residual])
+            return x
+
+        short_branch = tcn_block(inputs, 32)
+        short_pool = GlobalAveragePooling1D()(short_branch)
+
+        long_branch = tcn_block(inputs, 48)
+        long_pool = GlobalAveragePooling1D()(long_branch)
+
+        merged = Concatenate()([short_pool, long_pool])
+        x = Dense(128, activation="relu")(merged)
+        x = Dropout(0.1)(x)
+        x = Dense(64, activation="relu")(x)
+        outputs = Dense(num_classes, activation="softmax")(x)
+
+        model = Model(inputs, outputs)
+
+        def focal_loss(y_true, y_pred, gamma: float = 2.0, alpha: float = 0.25):
+            y_true = tf.one_hot(tf.cast(y_true, tf.int32), depth=num_classes)
+            y_pred = tf.clip_by_value(y_pred, 1e-7, 1 - 1e-7)
+            ce = -y_true * tf.math.log(y_pred)
+            weight = alpha * tf.pow(1 - y_pred, gamma)
+            return tf.reduce_sum(weight * ce, axis=-1)
+
+        loss_fn = focal_loss if loss_type == "focal" else "sparse_categorical_crossentropy"
+        optimizer = Adam(learning_rate=1e-3, clipnorm=1.0)
+        model.compile(optimizer=optimizer, loss=loss_fn, metrics=["accuracy"])
+        return model
+
+    def create_dual_gru_model(
+        self, input_shape: Tuple[int, int], num_classes: int = 2
+    ) -> Optional[Model]:
+        """创建双分支GRU模型"""
+
+        if not TENSORFLOW_AVAILABLE:
+            print("TensorFlow未安装，无法创建GRU模型")
+            return None
+
+        inputs = Input(shape=input_shape)
+        short = GRU(96, return_sequences=True, dropout=0.2)(inputs)
+        short = GRU(96, dropout=0.2)(short)
+
+        long = GRU(64, return_sequences=True)(inputs)
+        long = GRU(64)(long)
+
+        merged = Concatenate()([short, long])
+        x = Dense(128, activation="relu")(merged)
+        x = Dropout(0.2)(x)
+        x = Dense(128, activation="relu")(x)
+        outputs = Dense(num_classes, activation="softmax")(x)
+
+        optimizer = Adam(learning_rate=1e-3, clipnorm=1.0)
+        model = Model(inputs, outputs)
+        model.compile(optimizer=optimizer, loss="sparse_categorical_crossentropy", metrics=["accuracy"])
+        return model
+
+    def create_tiny_transformer_model(
+        self, input_shape: Tuple[int, int], num_classes: int = 2
+    ) -> Optional[Model]:
+        """创建双分支Tiny-Transformer模型"""
+
+        if not TENSORFLOW_AVAILABLE:
+            print("TensorFlow未安装，无法创建Transformer模型")
+            return None
+
+        inputs = Input(shape=input_shape)
+
+        x = Dense(64)(inputs)
+
+        class PositionalEncoding(tf.keras.layers.Layer):
+            def __init__(self, d_model: int):
+                super().__init__()
+                self.d_model = d_model
+
+            def call(self, x):
+                pos = tf.range(tf.shape(x)[1], dtype=tf.float32)[:, tf.newaxis]
+                i = tf.range(self.d_model, dtype=tf.float32)[tf.newaxis, :]
+                angle_rates = 1 / tf.pow(10000.0, (2 * (i // 2)) / self.d_model)
+                angle_rads = pos * angle_rates
+                sines = tf.sin(angle_rads[:, 0::2])
+                cosines = tf.cos(angle_rads[:, 1::2])
+                pos_encoding = tf.concat([sines, cosines], axis=-1)
+                pos_encoding = pos_encoding[tf.newaxis, ...]
+                return x + pos_encoding
+
+        x = PositionalEncoding(64)(x)
+
+        def transformer_block(x: tf.Tensor, ffn_dim: int) -> tf.Tensor:
+            attn = MultiHeadAttention(num_heads=4, key_dim=64, dropout=0.1)(x, x)
+            attn = Dropout(0.1)(attn)
+            x = LayerNormalization()(Add()([x, attn]))
+            ffn = Dense(ffn_dim, activation="relu", kernel_regularizer=tf.keras.regularizers.l2(1e-5))(x)
+            ffn = Dropout(0.1)(ffn)
+            ffn = Dense(64, kernel_regularizer=tf.keras.regularizers.l2(1e-5))(ffn)
+            x = LayerNormalization()(Add()([x, ffn]))
+            return x
+
+        short = transformer_block(x, 128)
+        short = transformer_block(short, 128)
+        short_pool = Lambda(lambda t: t[:, 0, :])(short)
+
+        long = transformer_block(x, 256)
+        long = transformer_block(long, 256)
+        long_pool = Lambda(lambda t: t[:, 0, :])(long)
+
+        merged = Concatenate()([short_pool, long_pool])
+        x = Dense(128, activation="relu")(merged)
+        x = Dropout(0.1)(x)
+        x = Dense(128, activation="relu")(x)
+        outputs = Dense(num_classes, activation="softmax")(x)
+
+        optimizer = Adam(learning_rate=1e-3, clipnorm=0.5)
+        model = Model(inputs, outputs)
+        model.compile(optimizer=optimizer, loss="sparse_categorical_crossentropy", metrics=["accuracy"])
+        return model
+
+    def create_model_by_name(
+        self, name: str, input_shape: Tuple[int, int], num_classes: int = 2
+    ) -> Optional[Model]:
+        """根据名称创建模型，便于在训练时灵活选择"""
+
+        if name == "tcn":
+            return self.create_tcn_model(input_shape, num_classes)
+        if name == "gru_dual":
+            return self.create_dual_gru_model(input_shape, num_classes)
+        if name == "tiny_transformer":
+            return self.create_tiny_transformer_model(input_shape, num_classes)
+        if name == "lstm":
+            return self.create_lstm_model(input_shape, num_classes)
+        if name == "gru":
+            return self.create_gru_model(input_shape, num_classes)
+        if name == "cnn_lstm":
+            return self.create_cnn_lstm_model(input_shape, num_classes)
+        raise ValueError(f"未知模型类型: {name}")
     
     def create_gru_model(self, input_shape: Tuple[int, int], num_classes: int = 2) -> Optional[Model]:
         """
@@ -507,6 +699,9 @@ if __name__ == "__main__":
     if TENSORFLOW_AVAILABLE:
         lstm_model = trainer.create_lstm_model((60, 10))  # 60个时间步，10个特征
         gru_model = trainer.create_gru_model((60, 10))
+        # 演示新加入的模型创建方式
+        tcn_model = trainer.create_model_by_name("tcn", (60, 10))
+        tiny_transformer = trainer.create_model_by_name("tiny_transformer", (60, 10))
         print("深度学习模型创建完成")
     
     traditional_models = trainer.create_traditional_models()

--- a/backend/models/train_model.py
+++ b/backend/models/train_model.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+模型训练脚本示例
+================
+
+该脚本演示如何从命令行选择不同的深度学习模型进行训练。
+默认假设预处理后的特征与标签以 ``npy`` 文件形式保存在 ``data`` 目录下。
+用户可通过 ``--model`` 参数选择 TCN、双分支GRU 或 Tiny-Transformer 等模型。
+"""
+
+import argparse
+from pathlib import Path
+import numpy as np
+
+from .model_trainer import ModelTrainer
+
+
+def load_data(data_dir: Path):
+    """加载训练与验证数据"""
+    X_train = np.load(data_dir / "X_train.npy")
+    y_train = np.load(data_dir / "y_train.npy")
+    X_val = np.load(data_dir / "X_val.npy")
+    y_val = np.load(data_dir / "y_val.npy")
+    return X_train, y_train, X_val, y_val
+
+
+def main():
+    parser = argparse.ArgumentParser(description="深度学习模型训练脚本")
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="tcn",
+        choices=["tcn", "gru_dual", "tiny_transformer", "lstm", "gru", "cnn_lstm"],
+        help="选择训练的模型类型",
+    )
+    parser.add_argument("--data", type=str, default="../data", help="预处理数据所在目录")
+    parser.add_argument("--epochs", type=int, default=10, help="训练轮数")
+    parser.add_argument("--batch_size", type=int, default=32, help="批次大小")
+    args = parser.parse_args()
+
+    data_dir = Path(args.data)
+    X_train, y_train, X_val, y_val = load_data(data_dir)
+
+    trainer = ModelTrainer()
+    model = trainer.create_model_by_name(args.model, input_shape=X_train.shape[1:])
+    if model is None:
+        raise RuntimeError("模型创建失败，可能未安装TensorFlow")
+
+    trainer.train_deep_learning_model(
+        model,
+        args.model,
+        X_train,
+        y_train,
+        X_val,
+        y_val,
+        epochs=args.epochs,
+        batch_size=args.batch_size,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add TCN/1D CNN, dual-branch GRU, and tiny transformer models with Chinese docs
- provide model selector to choose among multiple architectures
- include command line training helper script

## Testing
- `pytest`
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement flake8)*
- `pip install numpy` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68bef2f544f88325adfa5aabcbd0c704