### PR TITLE
feat: split dataset and add on-the-fly MA branch

### DIFF
--- a/backend/data/dataset_loader.py
+++ b/backend/data/dataset_loader.py
@@ -1,0 +1,74 @@
+import numpy as np
+import pandas as pd
+from typing import Tuple
+
+
+def load_dual_branch_dataset(
+    csv_path: str,
+    seq_len: int = 20,
+    test_ratio: float = 0.2,
+    ma_4h_window: int = 16,
+    ma_24h_window: int = 96,
+    ma_4h_steps: int = 6,
+    ma_24h_steps: int = 5,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Load 15m kline features and construct dual-branch dataset.
+
+    The main branch uses sequential 15m features. The auxiliary branch is
+    built on-the-fly by computing 4-hour and 24-hour moving averages and
+    collecting the most recent ``ma_4h_steps`` and ``ma_24h_steps`` values
+    respectively.
+
+    Args:
+        csv_path: Path to ``btcusdt_15m_features.csv``.
+        seq_len: Length of the main 15m feature sequence.
+        test_ratio: Fraction of samples reserved for the test set (taken
+            from the tail of the time series).
+        ma_4h_window: Number of 15m candles in a 4‑hour window (default 16).
+        ma_24h_window: Number of 15m candles in a 24‑hour window (default 96).
+        ma_4h_steps: Number of past 4‑hour averages to keep (default 6 → 1 day).
+        ma_24h_steps: Number of past 24‑hour averages to keep (default 5 → 5 days).
+
+    Returns:
+        Tuple of training and testing arrays:
+        ``(X_train_main, X_train_aux, y_train, X_test_main, X_test_aux, y_test)``
+    """
+    df = pd.read_csv(csv_path)
+    df = df.sort_values("timestamp").reset_index(drop=True)
+
+    feature_cols = [c for c in df.columns if c not in ["datetime"]]
+    data_main = df[feature_cols].values.astype(np.float32)
+    close = df["close"].values.astype(np.float32)
+
+    # Moving averages
+    ma_4h = pd.Series(close).rolling(window=ma_4h_window).mean()
+    ma_24h = pd.Series(close).rolling(window=ma_24h_window).mean()
+    ma_total_steps = ma_4h_steps + ma_24h_steps
+
+    X_main, X_aux, y = [], [], []
+    start_idx = max(
+        seq_len - 1,
+        ma_4h_window + ma_4h_steps - 2,
+        ma_24h_window + ma_24h_steps - 2,
+    )
+
+    for i in range(start_idx, len(df) - 1):
+        seq_main = data_main[i - seq_len + 1 : i + 1]
+        seq4 = ma_4h.iloc[i - ma_4h_steps + 1 : i + 1].values
+        seq24 = ma_24h.iloc[i - ma_24h_steps + 1 : i + 1].values
+        if np.isnan(seq4).any() or np.isnan(seq24).any():
+            continue
+        X_main.append(seq_main)
+        X_aux.append(np.concatenate([seq4, seq24]).reshape(ma_total_steps, 1))
+        y.append(int(close[i + 1] > close[i]))
+
+    X_main = np.array(X_main, dtype=np.float32)
+    X_aux = np.array(X_aux, dtype=np.float32)
+    y = np.array(y, dtype=np.int64)
+
+    split_idx = int(len(X_main) * (1 - test_ratio))
+    X_train_main, X_test_main = X_main[:split_idx], X_main[split_idx:]
+    X_train_aux, X_test_aux = X_aux[:split_idx], X_aux[split_idx:]
+    y_train, y_test = y[:split_idx], y[split_idx:]
+
+    return X_train_main, X_train_aux, y_train, X_test_main, X_test_aux, y_test

--- a/backend/models/train_model.py
+++ b/backend/models/train_model.py
@@ -14,10 +14,11 @@ from pathlib import Path
 import numpy as np
 
 from .model_trainer import ModelTrainer
+from ..data.dataset_loader import load_dual_branch_dataset
 
 
-def load_data(data_dir: Path):
-    """加载训练与验证数据"""
+def load_npy_data(data_dir: Path):
+    """加载预先保存的npy数据"""
     X_train = np.load(data_dir / "X_train.npy")
     y_train = np.load(data_dir / "y_train.npy")
     X_val = np.load(data_dir / "X_val.npy")
@@ -40,10 +41,27 @@ def main():
     args = parser.parse_args()
 
     data_dir = Path(args.data)
-    X_train, y_train, X_val, y_val = load_data(data_dir)
+
+    if args.model == "gru_dual":
+        csv_path = data_dir / "processed" / "btcusdt_15m_features.csv"
+        (
+            X_train_main,
+            X_train_aux,
+            y_train,
+            X_test_main,
+            X_test_aux,
+            y_test,
+        ) = load_dual_branch_dataset(str(csv_path))
+        X_train = [X_train_main, X_train_aux]
+        X_val = [X_test_main, X_test_aux]
+        input_shape = (X_train_main.shape[1:], X_train_aux.shape[1:])
+        y_val = y_test
+    else:
+        X_train, y_train, X_val, y_val = load_npy_data(data_dir)
+        input_shape = X_train.shape[1:]
 
     trainer = ModelTrainer()
-    model = trainer.create_model_by_name(args.model, input_shape=X_train.shape[1:])
+    model = trainer.create_model_by_name(args.model, input_shape=input_shape)
     if model is None:
         raise RuntimeError("模型创建失败，可能未安装TensorFlow")
 
@@ -57,6 +75,8 @@ def main():
         epochs=args.epochs,
         batch_size=args.batch_size,
     )
+
+    trainer.evaluate_model(model, X_val, y_val)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add dataset loader that splits data and builds on-the-fly 4h/24h moving-average features
- extend dual-branch GRU to accept second MA input and report test metrics
- update training script to use new loader, split data tail for testing, and evaluate model

## Testing
- `python -m py_compile backend/data/dataset_loader.py backend/models/model_trainer.py backend/models/train_model.py`
- `python backend/models/train_model.py --help` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68c78ff43a688325891a35d68a40ccdf